### PR TITLE
[#39] 주문 생성시 상품 재고 차감 후 주문 상태 변경

### DIFF
--- a/order-service/build.gradle
+++ b/order-service/build.gradle
@@ -38,6 +38,10 @@ dependencies {
     implementation group: 'org.postgresql', name: 'postgresql', version: '42.7.4'
     runtimeOnly 'org.postgresql:postgresql'
 
+    //kafka
+    implementation 'org.springframework.kafka:spring-kafka'
+    testImplementation 'org.springframework.kafka:spring-kafka-test'
+
     //lombok
     compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'

--- a/order-service/src/main/java/org/mosaic/order_service/application/dtos/OrderResponse.java
+++ b/order-service/src/main/java/org/mosaic/order_service/application/dtos/OrderResponse.java
@@ -1,0 +1,46 @@
+package org.mosaic.order_service.application.dtos;
+
+import java.util.List;
+import lombok.Builder;
+import lombok.Getter;
+import org.mosaic.order_service.domain.entity.Order;
+
+@Getter
+public class OrderResponse {
+
+  private final OrderInfo orderInfo;
+  private final List<OrderDetailResponse> orderDetails;
+
+  @Builder
+  private OrderResponse(OrderInfo orderInfo, List<OrderDetailResponse> orderDetails) {
+    this.orderInfo = orderInfo;
+    this.orderDetails = orderDetails;
+  }
+
+  public static OrderResponse of(Order order) {
+    List<OrderDetailResponse> detailResponses =
+        order.getOrderDetails().stream()
+            .map(
+                detail ->
+                    OrderDetailResponse.builder()
+                        .orderDetailUuid(detail.getOrderDetailUuid())
+                        .productId(detail.getProductId())
+                        .productName(detail.getProductName())
+                        .quantity(detail.getQuantity())
+                        .unitPrice(detail.getUnitPrice())
+                        .build())
+            .toList();
+
+    OrderInfo orderInfo =
+        new OrderInfo(
+            order.getOrderUuid(),
+            order.getSupplierCompanyId(),
+            order.getReceiverCompanyId(),
+            order.getOrderState(),
+            order.getOrderDate(),
+            order.getTotalAmount(),
+            order.getTotalQuantity());
+
+    return OrderResponse.builder().orderInfo(orderInfo).orderDetails(detailResponses).build();
+  }
+}

--- a/order-service/src/main/java/org/mosaic/order_service/application/dtos/ProductDeductDto.java
+++ b/order-service/src/main/java/org/mosaic/order_service/application/dtos/ProductDeductDto.java
@@ -1,0 +1,29 @@
+package org.mosaic.order_service.application.dtos;
+
+import java.util.List;
+import lombok.Builder;
+import lombok.Getter;
+import org.mosaic.order_service.domain.entity.Order;
+
+@Getter
+public class ProductDeductDto {
+  String productUuid;
+  Long quantity;
+
+  @Builder
+  private ProductDeductDto(String productUuid, Long quantity) {
+    this.productUuid = productUuid;
+    this.quantity = quantity;
+  }
+
+  public static List<ProductDeductDto> of(Order order) {
+    return order.getOrderDetails().stream()
+        .map(
+            detail ->
+                ProductDeductDto.builder()
+                    .productUuid(detail.getProductId())
+                    .quantity(detail.getQuantity())
+                    .build())
+        .toList();
+  }
+}

--- a/order-service/src/main/java/org/mosaic/order_service/application/service/OrderCommandService.java
+++ b/order-service/src/main/java/org/mosaic/order_service/application/service/OrderCommandService.java
@@ -1,23 +1,35 @@
 package org.mosaic.order_service.application.service;
 
+import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.mosaic.order_service.application.dtos.CreateOrderDto;
 import org.mosaic.order_service.application.dtos.CreateOrderResponse;
+import org.mosaic.order_service.application.dtos.ProductDeductDto;
 import org.mosaic.order_service.application.mapper.OrderMapper;
 import org.mosaic.order_service.domain.entity.Order;
 import org.mosaic.order_service.domain.repository.OrderRepository;
+import org.mosaic.order_service.infrastructure.message.ProductDeductProducer;
 import org.springframework.stereotype.Service;
 
 @Service
+@Transactional
 @RequiredArgsConstructor
+@Slf4j(topic = "OrderCommandService")
 public class OrderCommandService {
 
   private final OrderRepository orderRepository;
   private final OrderMapper orderMapper;
+  private final ProductDeductProducer productDeductProducer;
 
   public CreateOrderResponse createOrder(CreateOrderDto dto) {
     Order newOrder = orderMapper.CreateOrderDtoToEntity(dto);
     orderRepository.save(newOrder);
+
+    log.info("orderId: {}", newOrder.getOrderId());
+
+    productDeductProducer.send(
+        "PRODUCT_DEDUCT_QUANTITY", newOrder.getOrderUuid(), ProductDeductDto.of(newOrder));
 
     return CreateOrderResponse.of(newOrder);
   }

--- a/order-service/src/main/java/org/mosaic/order_service/application/service/OrderMessageService.java
+++ b/order-service/src/main/java/org/mosaic/order_service/application/service/OrderMessageService.java
@@ -1,0 +1,29 @@
+package org.mosaic.order_service.application.service;
+
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.mosaic.order_service.domain.entity.Order;
+import org.mosaic.order_service.domain.enums.OrderState;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+@Slf4j
+public class OrderMessageService {
+
+  private final OrderQueryService orderQueryService;
+
+  public void changeOrderStateToCreated(String orderUuid) {
+    Order order = orderQueryService.findOrderUuid(orderUuid);
+    order.addOrderStateHistory(OrderState.CREATED);
+  }
+
+  public void changeOrderStateToCancel(String orderUuid) {
+    Order order = orderQueryService.findOrderUuid(orderUuid);
+    if (!order.getOrderState().equals(OrderState.CANCELLED)) {
+      order.addOrderStateHistory(OrderState.CANCELLED);
+    }
+  }
+}

--- a/order-service/src/main/java/org/mosaic/order_service/application/service/OrderQueryService.java
+++ b/order-service/src/main/java/org/mosaic/order_service/application/service/OrderQueryService.java
@@ -1,0 +1,27 @@
+package org.mosaic.order_service.application.service;
+
+import lombok.RequiredArgsConstructor;
+import org.mosaic.order_service.application.dtos.OrderResponse;
+import org.mosaic.order_service.domain.entity.Order;
+import org.mosaic.order_service.domain.repository.OrderRepository;
+import org.mosaic.order_service.libs.exception.OrderNotFoundException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class OrderQueryService {
+
+  private final OrderRepository orderRepository;
+
+  public Order findOrderUuid(String uuid) {
+    return orderRepository
+        .findByOrderUuid(uuid)
+        .orElseThrow(() -> new OrderNotFoundException(uuid));
+  }
+
+  public OrderResponse getProductResponse(String uuid) {
+    return OrderResponse.of(findOrderUuid(uuid));
+  }
+}

--- a/order-service/src/main/java/org/mosaic/order_service/domain/entity/Order.java
+++ b/order-service/src/main/java/org/mosaic/order_service/domain/entity/Order.java
@@ -89,6 +89,7 @@ public class Order extends BaseEntity {
 
   public void addOrderStateHistory(OrderState state) {
     OrderStateHistory history = OrderStateHistory.builder().orderState(state).build();
+    this.orderState = state;
     history.changeOrder(this);
     this.orderStateHistory.add(history);
   }

--- a/order-service/src/main/java/org/mosaic/order_service/domain/repository/OrderRepository.java
+++ b/order-service/src/main/java/org/mosaic/order_service/domain/repository/OrderRepository.java
@@ -1,6 +1,6 @@
 package org.mosaic.order_service.domain.repository;
 
-
+import java.util.Optional;
 import org.mosaic.order_service.domain.entity.Order;
 import org.springframework.stereotype.Repository;
 
@@ -8,4 +8,6 @@ import org.springframework.stereotype.Repository;
 public interface OrderRepository {
 
   Order save(Order newOrder);
+
+  Optional<Order> findByOrderUuid(String uuid);
 }

--- a/order-service/src/main/java/org/mosaic/order_service/infrastructure/message/ProductDeductProducer.java
+++ b/order-service/src/main/java/org/mosaic/order_service/infrastructure/message/ProductDeductProducer.java
@@ -1,0 +1,51 @@
+package org.mosaic.order_service.infrastructure.message;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.kafka.clients.producer.ProducerRecord;
+import org.mosaic.order_service.application.dtos.ProductDeductDto;
+import org.springframework.data.domain.AuditorAware;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j(topic = "ProductDeductProducer in OrderServer")
+public class ProductDeductProducer {
+  private final KafkaTemplate<String, String> kafkaTemplate;
+  private final AuditorAware<String> auditorAware;
+  private final ObjectMapper objectMapper;
+
+  public void send(String topic, String orderUuid, List<ProductDeductDto> dto) {
+    try {
+      String userId = auditorAware.getCurrentAuditor().orElse("unknown");
+
+      String jsonPayload = objectMapper.writeValueAsString(dto);
+
+      ProducerRecord<String, String> producerRecord =
+          new ProducerRecord<>(topic, orderUuid, jsonPayload);
+      producerRecord.headers().add("UUID", orderUuid.getBytes(StandardCharsets.UTF_8));
+      producerRecord.headers().add("USER_ID", userId.getBytes(StandardCharsets.UTF_8));
+
+      kafkaTemplate
+          .send(producerRecord)
+          .whenComplete(
+              (result, ex) -> {
+                if (ex == null) {
+                  log.info(
+                      "Sent ProductDeductDto of {} to ProductServer with auditor {}",
+                      orderUuid,
+                      userId);
+                } else {
+                  log.error("Error sending ProductDeductDto of {} to ProductServer", orderUuid, ex);
+                }
+              });
+    } catch (JsonProcessingException e) {
+      log.error("Error serializing ProductDeductDto for order {}", orderUuid, e);
+    }
+  }
+}

--- a/order-service/src/main/java/org/mosaic/order_service/infrastructure/message/ProductDeductResultConsumer.java
+++ b/order-service/src/main/java/org/mosaic/order_service/infrastructure/message/ProductDeductResultConsumer.java
@@ -1,0 +1,42 @@
+package org.mosaic.order_service.infrastructure.message;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.mosaic.order_service.application.service.OrderMessageService;
+import org.mosaic.order_service.libs.common.config.JpaAuditConfig;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.messaging.handler.annotation.Header;
+import org.springframework.messaging.handler.annotation.Payload;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class ProductDeductResultConsumer {
+
+  private final OrderMessageService orderMessageService;
+  private final JpaAuditConfig jpaAuditConfig;
+
+  @KafkaListener(topics = "SUCCESS_PRODUCT_QUANTITY", groupId = "order-service")
+  public void handleSuccessDeduction(@Payload String orderUuid, @Header("USER_ID") String userId) {
+    log.info("Product deduction successful for order UUID: {}, User ID: {}", orderUuid, userId);
+    jpaAuditing(userId);
+    orderMessageService.changeOrderStateToCreated(orderUuid);
+  }
+
+  @KafkaListener(topics = "ERROR_PRODUCT_QUANTITY", groupId = "order-service")
+  public void handleErrorDeduction(
+      @Payload String orderUuid, @Header("USER_ID") String userId, @Payload String errorMessage) {
+    log.error(
+        "Product deduction failed for order UUID: {}, User ID: {}. Error: {}",
+        orderUuid,
+        userId,
+        errorMessage);
+    jpaAuditing(userId);
+    orderMessageService.changeOrderStateToCancel(orderUuid);
+  }
+
+  private void jpaAuditing(String userId) {
+    jpaAuditConfig.getUserId(userId);
+  }
+}

--- a/order-service/src/main/java/org/mosaic/order_service/libs/common/config/JpaAuditConfig.java
+++ b/order-service/src/main/java/org/mosaic/order_service/libs/common/config/JpaAuditConfig.java
@@ -2,8 +2,9 @@ package org.mosaic.order_service.libs.common.config;
 
 import static org.mosaic.order_service.libs.common.constant.HttpHeaderConstants.*;
 
+import jakarta.servlet.http.HttpServletRequest;
 import java.util.Optional;
-
+import lombok.RequiredArgsConstructor;
 import org.mosaic.order_service.libs.exception.AuthException;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -11,22 +12,32 @@ import org.springframework.data.domain.AuditorAware;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 import org.springframework.http.HttpStatus;
 
-import jakarta.servlet.http.HttpServletRequest;
-import lombok.RequiredArgsConstructor;
-
 @Configuration
 @EnableJpaAuditing
 @RequiredArgsConstructor
 public class JpaAuditConfig {
+
   private final HttpServletRequest request;
+  private String userId;
 
   @Bean
   public AuditorAware<String> auditorProvider() {
-    return () -> {
-      String header =
-          Optional.ofNullable(request.getHeader(HEADER_USER_ID))
-              .orElseThrow(() -> new AuthException(HttpStatus.BAD_REQUEST, "잘못된 요청입니다."));
-      return Optional.of(header);
-    };
+    return this::getCurrentAuditor;
+  }
+
+  public void getUserId(String userId) {
+    this.userId = userId;
+  }
+
+  private Optional<String> getCurrentAuditor() {
+    return Optional.ofNullable(userId).or(this::getHeaderUserId).or(this::throwAuthException);
+  }
+
+  private Optional<String> getHeaderUserId() {
+    return Optional.ofNullable(request.getHeader(HEADER_USER_ID));
+  }
+
+  private Optional<String> throwAuthException() {
+    throw new AuthException(HttpStatus.UNAUTHORIZED, "잘못된 요청입니다.");
   }
 }

--- a/order-service/src/main/java/org/mosaic/order_service/libs/common/config/KafkaConfig.java
+++ b/order-service/src/main/java/org/mosaic/order_service/libs/common/config/KafkaConfig.java
@@ -1,0 +1,25 @@
+package org.mosaic.order_service.libs.common.config;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import org.mosaic.order_service.infrastructure.message.ProductDeductProducer;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.domain.AuditorAware;
+import org.springframework.kafka.core.KafkaTemplate;
+
+@ConditionalOnProperty(value = "kafka.enabled", matchIfMissing = true)
+@RequiredArgsConstructor
+@Configuration
+public class KafkaConfig {
+
+  private final KafkaTemplate<String, String> kafkaTemplate;
+  private final AuditorAware<String> auditorAware;
+  private final ObjectMapper objectMapper;
+
+  @Bean
+  public ProductDeductProducer productDeductProducer() {
+    return new ProductDeductProducer(kafkaTemplate, auditorAware, objectMapper);
+  }
+}

--- a/order-service/src/main/java/org/mosaic/order_service/libs/exception/GlobalExceptionHandler.java
+++ b/order-service/src/main/java/org/mosaic/order_service/libs/exception/GlobalExceptionHandler.java
@@ -23,7 +23,7 @@ public class GlobalExceptionHandler {
     ex.getBindingResult()
         .getAllErrors()
         .forEach(
-            (error) -> {
+            error -> {
               String fieldName = ((FieldError) error).getField();
               String errorMessage = error.getDefaultMessage();
               errors.put(fieldName, errorMessage);
@@ -42,5 +42,14 @@ public class GlobalExceptionHandler {
   @ExceptionHandler(AuthException.class)
   public ResponseEntity<MosaicResponse<String>> handleCustomException(AuthException e) {
     return ApiResponseUtils.failed(e.getStatus(), e);
+  }
+
+  @ExceptionHandler(OrderNotFoundException.class)
+  @ResponseStatus(HttpStatus.NOT_FOUND)
+  public ResponseEntity<Map<String, String>> handleProductNotFoundException(
+      OrderNotFoundException ex) {
+    Map<String, String> error = new HashMap<>();
+    error.put("error", ex.getMessage());
+    return ResponseEntity.status(HttpStatus.NOT_FOUND).body(error);
   }
 }

--- a/order-service/src/main/java/org/mosaic/order_service/libs/exception/OrderNotFoundException.java
+++ b/order-service/src/main/java/org/mosaic/order_service/libs/exception/OrderNotFoundException.java
@@ -1,0 +1,7 @@
+package org.mosaic.order_service.libs.exception;
+
+public class OrderNotFoundException extends RuntimeException {
+  public OrderNotFoundException(String uuid) {
+    super("해당 %s로 주문을 찾을 수 없습니다".formatted(uuid));
+  }
+}

--- a/order-service/src/main/java/org/mosaic/order_service/presentation/controller/OrderController.java
+++ b/order-service/src/main/java/org/mosaic/order_service/presentation/controller/OrderController.java
@@ -5,10 +5,14 @@ import static org.mosaic.order_service.libs.util.ApiResponseUtils.*;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.mosaic.order_service.application.dtos.CreateOrderResponse;
+import org.mosaic.order_service.application.dtos.OrderResponse;
 import org.mosaic.order_service.application.service.OrderCommandService;
+import org.mosaic.order_service.application.service.OrderQueryService;
 import org.mosaic.order_service.libs.util.MosaicResponse;
 import org.mosaic.order_service.presentation.dtos.CreateOrderRequest;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -19,10 +23,17 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping("/api/v1/orders")
 public class OrderController {
   private final OrderCommandService orderCommandService;
+  private final OrderQueryService orderQueryService;
 
   @PostMapping()
   public ResponseEntity<MosaicResponse<CreateOrderResponse>> createOrder(
       @Valid @RequestBody CreateOrderRequest req) {
     return created(orderCommandService.createOrder(req.toDto()));
+  }
+
+  @GetMapping("/{productUuid}")
+  public ResponseEntity<MosaicResponse<OrderResponse>> getProduct(
+      @PathVariable String productUuid) {
+    return ok(orderQueryService.getProductResponse(productUuid));
   }
 }

--- a/order-service/src/main/resources/application.yaml
+++ b/order-service/src/main/resources/application.yaml
@@ -25,6 +25,29 @@ spring:
         format_sql: true
         jdbc:
           time_zone: Asia/Seoul
-    
+    show-sql: true
+  kafka:
+    bootstrap-servers: localhost:9092
+    listener:
+      ack-mode: MANUAL
+    producer:
+      key-serializer: org.apache.kafka.common.serialization.StringSerializer
+      value-serializer: org.springframework.kafka.support.serializer.JsonSerializer
+    consumer:
+      group-id: order
+      auto-offset-reset: latest
+      key-deserializer: org.apache.kafka.common.serialization.StringDeserializer
+      value-deserializer: org.springframework.kafka.support.serializer.JsonDeserializer
+      properties:
+        spring:
+          json:
+            trusted:
+              packages: "*"
+
 server:
-  port: 19001
+  port: 19007
+
+eureka:
+  client:
+    service-url:
+      defaultZone: http://localhost:19090/eureka/

--- a/order-service/src/main/resources/http/Order.http
+++ b/order-service/src/main/resources/http/Order.http
@@ -1,5 +1,5 @@
 ### 주문 생성
-POST http://localhost:19001/api/v1/orders
+POST http://localhost:19007/api/v1/orders
 Content-Type: application/json
 X-User-Id: 550e8400-e29b-41d4-a716-446655440006
 
@@ -11,20 +11,43 @@ X-User-Id: 550e8400-e29b-41d4-a716-446655440006
     {
       "productId": "550e8400-e29b-41d4-a716-446655440000",
       "productName": "샤오미 전기 히터",
-      "quantity": 5,
+      "quantity": 10,
       "unitPrice": 100000
     },
     {
       "productId": "550e8400-e29b-41d4-a716-446655440002",
       "productName": "토요토미 옴니 230 KS-67H",
-      "quantity": 1,
+      "quantity": 10,
       "unitPrice": 200000
     },
     {
       "productId": "550e8400-e29b-41d4-a716-446655440005",
       "productName": "베어샤오슝 BEAR 발난로 DNQ-A02X1",
-      "quantity": 3,
+      "quantity": 10,
       "unitPrice": 30000
     }
   ]
 }
+
+### 주문 생성
+POST http://localhost:19007/api/v1/orders
+Content-Type: application/json
+X-User-Id: 550e8400-e29b-41d4-a716-446655440006
+
+
+{
+  "supplierCompanyId": "550e8400-e29b-41d4-a716-446655440000",
+  "receiverCompanyId": "550e8400-e29b-41d4-a716-446655440001",
+  "orderDetails": [
+    {
+      "productId": "550e8400-e29b-41d4-a716-446655440000",
+      "productName": "샤오미 전기 히터",
+      "quantity": 1000000,
+      "unitPrice": 100000
+    }
+  ]
+}
+
+
+###
+GET http://localhost:19007/api/v1/orders/cf515949-c358-47da-8ff1-f23076489758

--- a/product-service/build.gradle
+++ b/product-service/build.gradle
@@ -38,7 +38,10 @@ dependencies {
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
     implementation group: 'org.postgresql', name: 'postgresql', version: '42.7.4'
     runtimeOnly 'org.postgresql:postgresql'
-  
+
+    //kafka
+    implementation 'org.springframework.kafka:spring-kafka'
+    testImplementation 'org.springframework.kafka:spring-kafka-test'
 
     //lombok
     compileOnly 'org.projectlombok:lombok'

--- a/product-service/src/main/java/org/mosaic/product_service/application/dtos/ProductDeductDto.java
+++ b/product-service/src/main/java/org/mosaic/product_service/application/dtos/ProductDeductDto.java
@@ -1,0 +1,9 @@
+package org.mosaic.product_service.application.dtos;
+
+import lombok.Getter;
+
+@Getter
+public class ProductDeductDto {
+  String productUuid;
+  Long quantity;
+}

--- a/product-service/src/main/java/org/mosaic/product_service/application/service/ProductMessageService.java
+++ b/product-service/src/main/java/org/mosaic/product_service/application/service/ProductMessageService.java
@@ -1,0 +1,33 @@
+package org.mosaic.product_service.application.service;
+
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.mosaic.product_service.application.dtos.ProductDeductDto;
+import org.mosaic.product_service.domain.entity.Product;
+import org.mosaic.product_service.domain.repository.ProductRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class ProductMessageService {
+
+  private final ProductRepository productRepository;
+  private final ProductQueryService productQueryService;
+
+  public void deductProductQuantity(List<ProductDeductDto> dtos) {
+    try {
+      for (ProductDeductDto dto : dtos) {
+        Product product = productQueryService.findProductUuid(dto.getProductUuid());
+        product.deductQuantity(dto.getQuantity());
+        productRepository.save(product);
+        log.info("Deducted product {} quantity by createOrder", product.getProductName());
+      }
+    } catch (Exception e) {
+      log.error("Error deducting product quantity: {}", e.getMessage());
+    }
+  }
+}

--- a/product-service/src/main/java/org/mosaic/product_service/domain/entity/Product.java
+++ b/product-service/src/main/java/org/mosaic/product_service/domain/entity/Product.java
@@ -20,6 +20,7 @@ import lombok.NoArgsConstructor;
 import org.hibernate.annotations.SQLRestriction;
 import org.mosaic.product_service.domain.entity.enums.StockType;
 import org.mosaic.product_service.libs.common.entity.BaseEntity;
+import org.mosaic.product_service.libs.exception.InsufficientStockException;
 
 @Entity
 @Getter
@@ -110,5 +111,20 @@ public class Product extends BaseEntity {
     this.productPrice = productPrice;
     this.productDescription = productDescription;
     this.stockQuantity = stockHistories;
+  }
+
+  public void deductQuantity(Long quantity) {
+    if (quantity <= 0) {
+      throw new IllegalArgumentException("차감할 수량은 0보다 커야 합니다.");
+    }
+    if (stockQuantity == 0) {
+      throw new InsufficientStockException("재고가 없습니다.");
+    }
+    if (stockQuantity < quantity) {
+      throw new InsufficientStockException(
+          "요청한 수량(" + quantity + ")이 현재 재고(" + stockQuantity + ")보다 많습니다.");
+    }
+    this.stockQuantity -= quantity;
+    addStockHistory(quantity, StockType.OUTBOUND);
   }
 }

--- a/product-service/src/main/java/org/mosaic/product_service/domain/entity/ProductStockHistory.java
+++ b/product-service/src/main/java/org/mosaic/product_service/domain/entity/ProductStockHistory.java
@@ -25,32 +25,34 @@ import org.mosaic.product_service.libs.common.entity.BaseEntity;
 @SQLRestriction("IS_DELETE = FALSE AND IS_PUBLIC = TRUE")
 public class ProductStockHistory extends BaseEntity {
 
-	@Id
-	@GeneratedValue(strategy = GenerationType.IDENTITY)
-	@Column(name = "PRODUCT_STOCK_HISTORY_ID")
-	private Long productStockHistoryID;
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  @Column(name = "PRODUCT_STOCK_HISTORY_ID")
+  private Long productStockHistoryID;
 
-	@ManyToOne(fetch = FetchType.LAZY)
-	@JoinColumn(name = "PRODUCT_ID")
-	private Product product;
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "PRODUCT_ID")
+  private Product product;
 
-	@Column(name = "QUANTITY")
-	private Long quantity;
+  @Column(name = "QUANTITY")
+  private Long quantity;
 
-	@Enumerated(EnumType.STRING)
-	@Column(name = "STOCK_TYPE")
-	private StockType stockType;
+  @Enumerated(EnumType.STRING)
+  @Column(name = "STOCK_TYPE")
+  private StockType stockType;
 
-	@Builder
-	private ProductStockHistory(Product product, Long quantity, StockType stockType) {
-		this.product = product;
-		this.quantity = quantity;
-		this.stockType = stockType;
-	}
+  @Builder
+  private ProductStockHistory(Product product, Long quantity, StockType stockType) {
+    this.product = product;
+    this.quantity = quantity;
+    this.stockType = stockType;
+  }
 
-	public void update(Long quantity) {
-		this.quantity = quantity;
-	}
+  public void update(Long quantity) {
+    this.quantity = quantity;
+  }
+
+  void changeOrder(Product product) {
+    this.product = product;
+  }
 }
-
-

--- a/product-service/src/main/java/org/mosaic/product_service/infrastructure/jpa/ProductStockHistoryRepository.java
+++ b/product-service/src/main/java/org/mosaic/product_service/infrastructure/jpa/ProductStockHistoryRepository.java
@@ -1,9 +1,0 @@
-package org.mosaic.product_service.infrastructure.jpa;
-
-import org.mosaic.product_service.domain.entity.Product;
-import org.springframework.data.jpa.repository.JpaRepository;
-
-public interface ProductStockHistoryRepository extends
-	JpaRepository<Product, Long> {
-	void deleteAllByProductUuid(String productUuid);
-}

--- a/product-service/src/main/java/org/mosaic/product_service/infrastructure/message/ProductDeductConsumer.java
+++ b/product-service/src/main/java/org/mosaic/product_service/infrastructure/message/ProductDeductConsumer.java
@@ -1,0 +1,75 @@
+package org.mosaic.product_service.infrastructure.message;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.kafka.clients.producer.ProducerRecord;
+import org.mosaic.product_service.application.dtos.ProductDeductDto;
+import org.mosaic.product_service.application.service.ProductMessageService;
+import org.mosaic.product_service.libs.common.config.JpaAuditConfig;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.kafka.support.KafkaHeaders;
+import org.springframework.messaging.handler.annotation.Header;
+import org.springframework.messaging.handler.annotation.Payload;
+import org.springframework.messaging.handler.annotation.SendTo;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+@Slf4j(topic = "ProductDeductConsumer in ProductServer")
+public class ProductDeductConsumer {
+
+  private final ProductMessageService productMessageService;
+  private final ObjectMapper objectMapper;
+  private final KafkaTemplate<String, String> kafkaTemplate;
+  private final JpaAuditConfig jpaAuditConfig;
+
+  @KafkaListener(topics = "PRODUCT_DEDUCT_QUANTITY", groupId = "deduct-product")
+  @SendTo("PRODUCT_DEDUCT_REPLY")
+  public void handleProductQuantityDeduction(
+      @Header(KafkaHeaders.RECEIVED_KEY) String key,
+      @Header("UUID") String orderUuid,
+      @Header("USER_ID") String userId,
+      @Payload String payload) {
+
+    try {
+      log.info("Received message with UUID: {} and userId: {}", orderUuid, userId);
+      jpaAuditConfig.getUserId(userId);
+
+      List<ProductDeductDto> dtos = deserializePayload(payload);
+      productMessageService.deductProductQuantity(dtos);
+
+      log.info("Successfully processed deduction for order: {}", key);
+      sendSuccessMessage(orderUuid, userId);
+    } catch (Exception e) {
+      sendErrorMessage(orderUuid, userId, e.getMessage());
+      log.error("Error occurred while deduct product : {}", e.getMessage());
+    }
+  }
+
+  private List<ProductDeductDto> deserializePayload(String payload) throws JsonProcessingException {
+    return objectMapper.readValue(payload, new TypeReference<List<ProductDeductDto>>() {});
+  }
+
+  private void sendSuccessMessage(String orderUuid, String userId) {
+    ProducerRecord<String, String> producerRecord =
+        new ProducerRecord<>("SUCCESS_PRODUCT_QUANTITY", orderUuid, orderUuid);
+    producerRecord.headers().add("USER_ID", userId.getBytes(StandardCharsets.UTF_8));
+    kafkaTemplate.send(producerRecord);
+  }
+
+  private void sendErrorMessage(String orderUuid, String userId, String errorMessage) {
+    String fullErrorMessage = String.format("Order UUID: %s, Error: %s", orderUuid, errorMessage);
+    ProducerRecord<String, String> producerRecord =
+        new ProducerRecord<>("ERROR_PRODUCT_QUANTITY", orderUuid, fullErrorMessage);
+    producerRecord.headers().add("USER_ID", userId.getBytes(StandardCharsets.UTF_8));
+    kafkaTemplate.send(producerRecord);
+  }
+}

--- a/product-service/src/main/java/org/mosaic/product_service/libs/common/config/JpaAuditConfig.java
+++ b/product-service/src/main/java/org/mosaic/product_service/libs/common/config/JpaAuditConfig.java
@@ -1,9 +1,10 @@
 package org.mosaic.product_service.libs.common.config;
 
-import static org.mosaic.product_service.libs.common.constant.HttpHeaderConstants.*;
+import static org.mosaic.product_service.libs.common.constant.HttpHeaderConstants.HEADER_USER_ID;
 
+import jakarta.servlet.http.HttpServletRequest;
 import java.util.Optional;
-
+import lombok.RequiredArgsConstructor;
 import org.mosaic.product_service.libs.exception.AuthException;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -11,28 +12,33 @@ import org.springframework.data.domain.AuditorAware;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 import org.springframework.http.HttpStatus;
 
-import jakarta.servlet.http.HttpServletRequest;
-import lombok.RequiredArgsConstructor;
-
 @Configuration
 @EnableJpaAuditing
 @RequiredArgsConstructor
 public class JpaAuditConfig {
 
-    private final HttpServletRequest request;
+  private final HttpServletRequest request;
+  private String userId;
 
-    @Bean
-    public AuditorAware<String> auditorProvider() {
-        return () -> {
-            String header = Optional.ofNullable(
-                request.getHeader(HEADER_USER_ID))
-                .orElseThrow(
-                    () -> new AuthException(
-                        HttpStatus.UNAUTHORIZED,
-                        "잘못된 요청입니다.")
-                );
-            return Optional.of(header);
-        };
-    }
+  @Bean
+  public AuditorAware<String> auditorProvider() {
+    return this::getCurrentAuditor;
+  }
+
+  public void getUserId(String userId) {
+    this.userId = userId;
+  }
+
+  // Private 메서드
+  private Optional<String> getCurrentAuditor() {
+    return Optional.ofNullable(userId).or(this::getHeaderUserId).or(this::throwAuthException);
+  }
+
+  private Optional<String> getHeaderUserId() {
+    return Optional.ofNullable(request.getHeader(HEADER_USER_ID));
+  }
+
+  private Optional<String> throwAuthException() {
+    throw new AuthException(HttpStatus.UNAUTHORIZED, "잘못된 요청입니다.");
+  }
 }
-

--- a/product-service/src/main/java/org/mosaic/product_service/libs/exception/GlobalExceptionHandler.java
+++ b/product-service/src/main/java/org/mosaic/product_service/libs/exception/GlobalExceptionHandler.java
@@ -2,7 +2,6 @@ package org.mosaic.product_service.libs.exception;
 
 import java.util.HashMap;
 import java.util.Map;
-
 import org.mosaic.product_service.libs.util.ApiResponseUtils;
 import org.mosaic.product_service.libs.util.MosaicResponse;
 import org.springframework.http.HttpStatus;
@@ -16,45 +15,50 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
 @RestControllerAdvice
 public class GlobalExceptionHandler {
 
-	@ExceptionHandler(MethodArgumentNotValidException.class)
-	@ResponseStatus(HttpStatus.BAD_REQUEST)
-	public ResponseEntity<Map<String, String>>
-			handleValidationExceptions(MethodArgumentNotValidException ex) {
-		Map<String, String> errors = new HashMap<>();
-		ex.getBindingResult().getAllErrors().forEach((error) -> {
-			String fieldName = ((FieldError) error).getField();
-			String errorMessage = error.getDefaultMessage();
-			errors.put(fieldName, errorMessage);
-		});
-		return ResponseEntity.badRequest().body(errors);
-	}
+  @ExceptionHandler(MethodArgumentNotValidException.class)
+  @ResponseStatus(HttpStatus.BAD_REQUEST)
+  public ResponseEntity<Map<String, String>> handleValidationExceptions(
+      MethodArgumentNotValidException ex) {
+    Map<String, String> errors = new HashMap<>();
+    ex.getBindingResult()
+        .getAllErrors()
+        .forEach(
+            error -> {
+              String fieldName = ((FieldError) error).getField();
+              String errorMessage = error.getDefaultMessage();
+              errors.put(fieldName, errorMessage);
+            });
+    return ResponseEntity.badRequest().body(errors);
+  }
 
-	@ExceptionHandler({
-			NumberFormatException.class,
-			IllegalArgumentException.class
-	})
-	@ResponseStatus(HttpStatus.UNAUTHORIZED)
-	public ResponseEntity<Map<String, String>>
-			handleNumberFormatException(Exception ex) {
-		Map<String, String> errors = new HashMap<>();
-		errors.put("error", "잘못된 접근입니다 : " + ex.getMessage());
-		return ResponseEntity.badRequest().body(errors);
-	}
+  @ExceptionHandler({NumberFormatException.class, IllegalArgumentException.class})
+  @ResponseStatus(HttpStatus.UNAUTHORIZED)
+  public ResponseEntity<Map<String, String>> handleNumberFormatException(Exception ex) {
+    Map<String, String> errors = new HashMap<>();
+    errors.put("error", "잘못된 접근입니다 : " + ex.getMessage());
+    return ResponseEntity.badRequest().body(errors);
+  }
 
-	@ExceptionHandler(AuthException.class)
-	public ResponseEntity<MosaicResponse<String>>
-				handleAuthException(AuthException e) {
-		return ApiResponseUtils.failed(e.getStatus(), e);
-	}
+  @ExceptionHandler(AuthException.class)
+  public ResponseEntity<MosaicResponse<String>> handleAuthException(AuthException e) {
+    return ApiResponseUtils.failed(e.getStatus(), e);
+  }
 
-	@ExceptionHandler(ProductNotFoundException.class)
-	@ResponseStatus(HttpStatus.NOT_FOUND)
-	public ResponseEntity<Map<String, String>>
-			handleProductNotFoundException(ProductNotFoundException ex) {
-		Map<String, String> error = new HashMap<>();
-		error.put("error", ex.getMessage());
-		return ResponseEntity.status(HttpStatus.NOT_FOUND).body(error);
-	}
+  @ExceptionHandler(ProductNotFoundException.class)
+  @ResponseStatus(HttpStatus.NOT_FOUND)
+  public ResponseEntity<Map<String, String>> handleProductNotFoundException(
+      ProductNotFoundException ex) {
+    Map<String, String> error = new HashMap<>();
+    error.put("error", ex.getMessage());
+    return ResponseEntity.status(HttpStatus.NOT_FOUND).body(error);
+  }
+
+  @ExceptionHandler(InsufficientStockException.class)
+  @ResponseStatus(HttpStatus.BAD_REQUEST)
+  public ResponseEntity<Map<String, String>> handleInsufficientStockException(
+      InsufficientStockException ex) {
+    Map<String, String> error = new HashMap<>();
+    error.put("error", "재고 부족: " + ex.getMessage());
+    return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(error);
+  }
 }
-
-

--- a/product-service/src/main/java/org/mosaic/product_service/libs/exception/InsufficientStockException.java
+++ b/product-service/src/main/java/org/mosaic/product_service/libs/exception/InsufficientStockException.java
@@ -1,0 +1,7 @@
+package org.mosaic.product_service.libs.exception;
+
+public class InsufficientStockException extends RuntimeException {
+  public InsufficientStockException(String message) {
+    super(message);
+  }
+}

--- a/product-service/src/main/resources/application.yaml
+++ b/product-service/src/main/resources/application.yaml
@@ -1,5 +1,5 @@
 server:
-  port: 8080
+  port: 19008
 
 spring:
   application:
@@ -29,3 +29,25 @@ spring:
         format_sql: true
         jdbc:
           time_zone: Asia/Seoul
+
+  kafka:
+    bootstrap-servers: localhost:9092
+    listener:
+      ack-mode: MANUAL
+    producer:
+      key-serializer: org.apache.kafka.common.serialization.StringSerializer
+      value-serializer: org.springframework.kafka.support.serializer.JsonSerializer
+    consumer:
+      group-id: product
+      auto-offset-reset: latest
+      key-deserializer: org.apache.kafka.common.serialization.StringDeserializer
+      value-deserializer: org.springframework.kafka.support.serializer.JsonDeserializer
+      properties:
+        spring:
+          json:
+            trusted:
+              packages: "*"
+eureka:
+  client:
+    service-url:
+      defaultZone: http://localhost:19090/eureka/


### PR DESCRIPTION
## 기능 설명
-  #37 

## 작업 내용
- 주문 등록 시 상품 재고 확인 및 차감을 위한 메시지 전송 기능 구현
- HTTP 헤더의 값만으로 JPA Auditing 구현 되어져 있었음
- userId를 수동으로 설정할 수 있는 커스텀 기능 추가
- Kafka 메시지 헤더에 주문 UUID와 사용자 ID 포함
- 메시지 전송 과정의 에러 처리 및 로깅 구현
- 주문 uuid로 조회 기능 추가
- 각 서비스에 맞게 서버 포트 수정, 유레카 카프카 설정

## 수정 사항

## 추가 작업 예정



